### PR TITLE
Fixes #10 and Fixes #11

### DIFF
--- a/Classes/ScreenView.m
+++ b/Classes/ScreenView.m
@@ -25,7 +25,7 @@
     unsigned long hightable[256], lowtable[256];
     
     int width, height;
-    unsigned long *frameBuffer8888;
+    unsigned int *frameBuffer8888;
     CGColorSpaceRef colorSpace;
     CGDataProviderRef provider[2];
 	int currentProvider;


### PR DESCRIPTION
Longs are 4 bits in 32 bit architecture, but 8 bits in 64 bit architecture.  ints are 4 bits either way.  Fixes both the messed up screen, and crashes from out of bounds memory access.